### PR TITLE
feat: add GitHub Skills activity (fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -39,6 +39,12 @@ activities = {
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program. Time-sensitive registration!",
+        "schedule": "Special sessions, see announcements",
+        "max_participants": 50,
+        "participants": []
+    },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",


### PR DESCRIPTION
Ajout de l'activité "GitHub Skills" à la liste des activités disponibles pour inscription, conformément à l'issue #6. Cette activité est essentielle pour le programme de certifications GitHub et répond à une demande urgente des élèves.